### PR TITLE
 Rename the kakfa topic `task-results-{tenantId}` to be `contr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ env/
 # Python
 __pycache__/
 *.py[cod]
-*.pb.py
+**/*.pb.py
+**/*_pb2.py
+**/*_pb2_grpc.py
 *$py.class
 *.so
 .Python

--- a/.idea/fastRequest/fastRequestCollection.xml
+++ b/.idea/fastRequest/fastRequestCollection.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="fastRequestCollection">
+    <option name="detail">
+      <CollectionDetail>
+        <option name="childList">
+          <list>
+            <CollectionDetail>
+              <option name="groupId" value="1" />
+              <option name="id" value="1" />
+              <option name="name" value="Default Group" />
+              <option name="type" value="1" />
+            </CollectionDetail>
+          </list>
+        </option>
+        <option name="groupId" value="-1" />
+        <option name="id" value="0" />
+        <option name="name" value="Root" />
+        <option name="type" value="1" />
+      </CollectionDetail>
+    </option>
+  </component>
+</project>

--- a/docker-compose-java.yml
+++ b/docker-compose-java.yml
@@ -76,10 +76,6 @@ services:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET: earliest
       SPRING_KAFKA_CONSUMER_ENABLE_AUTO_COMMIT: false
-      SPRING_KAFKA_CONSUMER_KEY_DESERIALIZER: org.apache.kafka.common.serialization.StringDeserializer
-      SPRING_KAFKA_CONSUMER_VALUE_DESERIALIZER: org.apache.kafka.common.serialization.ByteArrayDeserializer
-      SPRING_KAFKA_PRODUCER_KEY_SERIALIZER: org.apache.kafka.common.serialization.StringSerializer
-      SPRING_KAFKA_PRODUCER_VALUE_SERIALIZER: org.apache.kafka.common.serialization.StringSerializer
     ports:
       - "8081:8080"
     healthcheck:
@@ -103,10 +99,6 @@ services:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET: earliest
       SPRING_KAFKA_CONSUMER_ENABLE_AUTO_COMMIT: false
-      SPRING_KAFKA_CONSUMER_KEY_DESERIALIZER: org.apache.kafka.common.serialization.StringDeserializer
-      SPRING_KAFKA_CONSUMER_VALUE_DESERIALIZER: org.apache.kafka.common.serialization.StringDeserializer
-      SPRING_KAFKA_PRODUCER_KEY_SERIALIZER: org.apache.kafka.common.serialization.StringSerializer
-      SPRING_KAFKA_PRODUCER_VALUE_SERIALIZER: org.apache.kafka.common.serialization.StringSerializer
     ports:
       - "8082:8080"
     healthcheck:
@@ -130,10 +122,6 @@ services:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET: earliest
       SPRING_KAFKA_CONSUMER_ENABLE_AUTO_COMMIT: false
-      SPRING_KAFKA_CONSUMER_KEY_DESERIALIZER: org.apache.kafka.common.serialization.StringDeserializer
-      SPRING_KAFKA_CONSUMER_VALUE_DESERIALIZER: org.apache.kafka.common.serialization.StringDeserializer
-      SPRING_KAFKA_PRODUCER_KEY_SERIALIZER: org.apache.kafka.common.serialization.StringSerializer
-      SPRING_KAFKA_PRODUCER_VALUE_SERIALIZER: org.apache.kafka.common.serialization.ByteArraySerializer
     ports:
       - "8083:8080"
     healthcheck:
@@ -157,10 +145,6 @@ services:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       SPRING_KAFKA_CONSUMER_AUTO_OFFSET_RESET: earliest
       SPRING_KAFKA_CONSUMER_ENABLE_AUTO_COMMIT: false
-      SPRING_KAFKA_CONSUMER_KEY_DESERIALIZER: org.apache.kafka.common.serialization.StringDeserializer
-      SPRING_KAFKA_CONSUMER_VALUE_DESERIALIZER: org.apache.kafka.common.serialization.StringDeserializer
-      SPRING_KAFKA_PRODUCER_KEY_SERIALIZER: org.apache.kafka.common.serialization.StringSerializer
-      SPRING_KAFKA_PRODUCER_VALUE_SERIALIZER: org.apache.kafka.common.serialization.ByteArraySerializer
     ports:
       - "8084:8080"
     healthcheck:

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     
     <groupId>com.pcallahan.agentic</groupId>
     <artifactId>scalable-agent-framework</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
     
     <name>Agentic Parent</name>

--- a/protos/plan.proto
+++ b/protos/plan.proto
@@ -36,7 +36,4 @@ message PlanExecution {
   
   // Input task result that triggered this plan
   string input_task_id = 4;
-  
-  // Plan-specific parameters (serialized as JSON)
-  string parameters = 5;
 }

--- a/protos/task.proto
+++ b/protos/task.proto
@@ -39,7 +39,4 @@ message TaskExecution {
   
   // Task type identifier for routing and processing
   string task_type = 3;
-  
-  // Task-specific parameters (serialized as JSON)
-  string parameters = 4;
 }

--- a/services/common-java/src/main/java/com/pcallahan/agentic/common/TenantAwareKafkaConfig.java
+++ b/services/common-java/src/main/java/com/pcallahan/agentic/common/TenantAwareKafkaConfig.java
@@ -13,8 +13,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ContainerProperties;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
-import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -68,8 +68,7 @@ public class TenantAwareKafkaConfig {
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
         props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, sessionTimeoutMs);
@@ -87,7 +86,7 @@ public class TenantAwareKafkaConfig {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
         props.put(ProducerConfig.ACKS_CONFIG, "all");
         props.put(ProducerConfig.RETRIES_CONFIG, 3);
         props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);

--- a/services/common-py/agentic_common/pb_utils.py
+++ b/services/common-py/agentic_common/pb_utils.py
@@ -1,0 +1,358 @@
+"""
+Protobuf utilities for consistent serialization and deserialization.
+
+This module provides utilities for consistent protobuf message handling
+across all Python microservices in the agentic framework.
+"""
+
+import json
+from typing import Any, Dict, Optional, Union
+from datetime import datetime
+
+from .pb import TaskExecution, PlanExecution, TaskResult, PlanResult, ExecutionHeader
+
+
+class ProtobufUtils:
+    """
+    Utilities for consistent protobuf message handling.
+    
+    Provides methods for serialization, deserialization, and validation
+    of protobuf messages across all Python services.
+    """
+    
+    @staticmethod
+    def serialize_task_execution(task_execution: TaskExecution) -> bytes:
+        """
+        Serialize TaskExecution protobuf message to bytes.
+        
+        Args:
+            task_execution: TaskExecution protobuf message
+            
+        Returns:
+            Serialized bytes
+            
+        Raises:
+            ValueError: If serialization fails
+        """
+        try:
+            return task_execution.SerializeToString()
+        except Exception as e:
+            raise ValueError(f"Failed to serialize TaskExecution: {e}")
+    
+    @staticmethod
+    def deserialize_task_execution(message_bytes: bytes) -> TaskExecution:
+        """
+        Deserialize bytes to TaskExecution protobuf message.
+        
+        Args:
+            message_bytes: Serialized protobuf message bytes
+            
+        Returns:
+            TaskExecution protobuf message
+            
+        Raises:
+            ValueError: If deserialization fails
+        """
+        try:
+            task_execution = TaskExecution()
+            task_execution.ParseFromString(message_bytes)
+            return task_execution
+        except Exception as e:
+            raise ValueError(f"Failed to deserialize TaskExecution: {e}")
+    
+    @staticmethod
+    def serialize_plan_execution(plan_execution: PlanExecution) -> bytes:
+        """
+        Serialize PlanExecution protobuf message to bytes.
+        
+        Args:
+            plan_execution: PlanExecution protobuf message
+            
+        Returns:
+            Serialized bytes
+            
+        Raises:
+            ValueError: If serialization fails
+        """
+        try:
+            return plan_execution.SerializeToString()
+        except Exception as e:
+            raise ValueError(f"Failed to serialize PlanExecution: {e}")
+    
+    @staticmethod
+    def deserialize_plan_execution(message_bytes: bytes) -> PlanExecution:
+        """
+        Deserialize bytes to PlanExecution protobuf message.
+        
+        Args:
+            message_bytes: Serialized protobuf message bytes
+            
+        Returns:
+            PlanExecution protobuf message
+            
+        Raises:
+            ValueError: If deserialization fails
+        """
+        try:
+            plan_execution = PlanExecution()
+            plan_execution.ParseFromString(message_bytes)
+            return plan_execution
+        except Exception as e:
+            raise ValueError(f"Failed to deserialize PlanExecution: {e}")
+    
+    @staticmethod
+    def create_execution_header(
+        execution_id: str,
+        tenant_id: str,
+        status: int,
+        graph_id: str = "",
+        lifetime_id: str = "",
+        parent_id: str = "",
+        attempt: int = 1,
+        iteration_idx: int = 0,
+        edge_taken: str = ""
+    ) -> ExecutionHeader:
+        """
+        Create a consistent ExecutionHeader protobuf message.
+        
+        Args:
+            execution_id: Unique execution identifier
+            tenant_id: Tenant identifier
+            status: Execution status enum value
+            graph_id: Graph identifier
+            lifetime_id: Lifetime identifier
+            parent_id: Parent execution identifier
+            attempt: Execution attempt number
+            iteration_idx: Current iteration index
+            edge_taken: ID of the edge that led to this execution
+            
+        Returns:
+            ExecutionHeader protobuf message
+        """
+        header = ExecutionHeader()
+        header.id = execution_id
+        header.tenant_id = tenant_id
+        header.status = status
+        header.graph_id = graph_id
+        header.lifetime_id = lifetime_id
+        header.parent_id = parent_id
+        header.attempt = attempt
+        header.iteration_idx = iteration_idx
+        header.edge_taken = edge_taken
+        header.created_at = datetime.utcnow().isoformat() + "Z"
+        return header
+    
+    @staticmethod
+    def create_task_result(
+        mime_type: str = "",
+        size_bytes: int = 0,
+        error_message: str = "",
+        inline_data: Optional[Dict[str, Any]] = None,
+        uri: str = ""
+    ) -> TaskResult:
+        """
+        Create a consistent TaskResult protobuf message.
+        
+        Args:
+            mime_type: MIME type of the result
+            size_bytes: Size of the result in bytes
+            error_message: Error message if execution failed
+            inline_data: Inline data dictionary
+            uri: URI reference to external data
+            
+        Returns:
+            TaskResult protobuf message
+        """
+        result = TaskResult()
+        result.mime_type = mime_type
+        result.size_bytes = size_bytes
+        result.error_message = error_message
+        result.uri = uri
+        
+        if inline_data:
+            # Convert dictionary to protobuf Any field
+            from google.protobuf import any_pb2, struct_pb2
+            any_msg = any_pb2.Any()
+            
+            # Create a Value message to hold the JSON data
+            value_msg = struct_pb2.Value()
+            value_msg.string_value = json.dumps(inline_data)
+            any_msg.Pack(value_msg)
+            result.inline_data.CopyFrom(any_msg)
+        
+        return result
+    
+    @staticmethod
+    def create_plan_result(
+        next_task_ids: Optional[list] = None,
+        metadata: Optional[Dict[str, str]] = None,
+        error_message: str = "",
+        confidence: float = 0.5,
+        upstream_tasks_results: Optional[list] = None
+    ) -> PlanResult:
+        """
+        Create a consistent PlanResult protobuf message.
+        
+        Args:
+            next_task_ids: List of next task IDs
+            metadata: Metadata dictionary
+            error_message: Error message if planning failed
+            confidence: Planning confidence score (0.0 to 1.0)
+            upstream_tasks_results: List of upstream TaskResult objects
+            
+        Returns:
+            PlanResult protobuf message
+        """
+        result = PlanResult()
+        result.error_message = error_message
+        result.confidence = confidence
+        
+        if next_task_ids:
+            result.next_task_ids.extend(next_task_ids)
+        
+        if metadata:
+            result.metadata.update(metadata)
+        
+        if upstream_tasks_results:
+            result.upstream_tasks_results.extend(upstream_tasks_results)
+        
+        return result
+    
+    @staticmethod
+    def validate_task_execution(task_execution: TaskExecution) -> bool:
+        """
+        Validate TaskExecution protobuf message.
+        
+        Args:
+            task_execution: TaskExecution protobuf message
+            
+        Returns:
+            True if valid, False otherwise
+        """
+        try:
+            # Check required fields
+            if not task_execution.header.id:
+                return False
+            if not task_execution.header.tenant_id:
+                return False
+            if not task_execution.task_type:
+                return False
+            
+            return True
+        except Exception:
+            return False
+    
+    @staticmethod
+    def validate_plan_execution(plan_execution: PlanExecution) -> bool:
+        """
+        Validate PlanExecution protobuf message.
+        
+        Args:
+            plan_execution: PlanExecution protobuf message
+            
+        Returns:
+            True if valid, False otherwise
+        """
+        try:
+            # Check required fields
+            if not plan_execution.header.id:
+                return False
+            if not plan_execution.header.tenant_id:
+                return False
+            if not plan_execution.plan_type:
+                return False
+            
+            return True
+        except Exception:
+            return False
+    
+    @staticmethod
+    def extract_task_result_data(task_result: TaskResult) -> Optional[Dict[str, Any]]:
+        """
+        Extract task result data from protobuf message.
+        
+        Args:
+            task_result: TaskResult protobuf message
+            
+        Returns:
+            Dictionary with result data or None
+        """
+        if task_result.HasField("inline_data"):
+            try:
+                # Convert Any protobuf to dictionary
+                from google.protobuf import struct_pb2
+                value_msg = struct_pb2.Value()
+                task_result.inline_data.Unpack(value_msg)
+                data = json.loads(value_msg.string_value)
+                return {
+                    "type": "inline",
+                    "data": data,
+                }
+            except Exception:
+                return None
+        elif task_result.uri:
+            return {
+                "type": "uri",
+                "uri": task_result.uri,
+            }
+        else:
+            return None
+    
+    @staticmethod
+    def extract_plan_result_data(plan_result: PlanResult) -> Dict[str, Any]:
+        """
+        Extract plan result data from protobuf message.
+        
+        Args:
+            plan_result: PlanResult protobuf message
+            
+        Returns:
+            Dictionary with result data
+        """
+        return {
+            "next_task_ids": list(plan_result.next_task_ids),
+            "metadata": dict(plan_result.metadata),
+            "error_message": plan_result.error_message,
+            "confidence": plan_result.confidence,
+        }
+    
+    @staticmethod
+    def to_json_safe_dict(protobuf_message) -> Dict[str, Any]:
+        """
+        Convert protobuf message to JSON-safe dictionary.
+        
+        Args:
+            protobuf_message: Protobuf message
+            
+        Returns:
+            JSON-safe dictionary
+        """
+        try:
+            # Use protobuf's built-in JSON serialization
+            from google.protobuf.json_format import MessageToDict
+            return MessageToDict(protobuf_message, including_default_value_fields=True)
+        except Exception as e:
+            # Fallback to manual conversion
+            try:
+                return MessageToDict(protobuf_message)
+            except Exception as e2:
+                raise ValueError(f"Failed to convert protobuf to JSON-safe dict: {e}, fallback: {e2}")
+    
+    @staticmethod
+    def from_json_safe_dict(data: Dict[str, Any], message_class) -> Any:
+        """
+        Convert JSON-safe dictionary to protobuf message.
+        
+        Args:
+            data: JSON-safe dictionary
+            message_class: Protobuf message class
+            
+        Returns:
+            Protobuf message
+        """
+        try:
+            # Use protobuf's built-in JSON deserialization
+            from google.protobuf.json_format import ParseDict
+            return ParseDict(data, message_class())
+        except Exception as e:
+            raise ValueError(f"Failed to convert JSON-safe dict to protobuf: {e}") 

--- a/services/common-py/test_protobuf_consistency.py
+++ b/services/common-py/test_protobuf_consistency.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+Test script to verify consistent protobuf serialization across all Python services.
+
+This script tests that all services can properly serialize and deserialize
+protobuf messages using the new ProtobufUtils.
+"""
+
+import sys
+import os
+import uuid
+from datetime import datetime
+
+# Add the common-py directory to the path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from agentic_common import ProtobufUtils
+from agentic_common.pb import TaskExecution, PlanExecution, TaskResult, PlanResult, ExecutionHeader
+
+
+def test_task_execution_serialization():
+    """Test TaskExecution serialization and deserialization."""
+    print("Testing TaskExecution serialization...")
+    
+    # Create a test TaskExecution
+    execution_id = str(uuid.uuid4())
+    tenant_id = "test-tenant"
+    
+    # Create execution header
+    header = ProtobufUtils.create_execution_header(
+        execution_id=execution_id,
+        tenant_id=tenant_id,
+        status=3,  # SUCCEEDED
+        graph_id="test-graph",
+        lifetime_id="test-lifetime"
+    )
+    
+    # Create task result
+    task_result = ProtobufUtils.create_task_result(
+        mime_type="application/json",
+        size_bytes=1024,
+        inline_data={"test": "data", "number": 42}
+    )
+    
+    # Create TaskExecution
+    task_execution = TaskExecution()
+    task_execution.header.CopyFrom(header)
+    task_execution.task_type = "test_task"
+    task_execution.result.CopyFrom(task_result)
+    
+    # Test serialization
+    try:
+        serialized = ProtobufUtils.serialize_task_execution(task_execution)
+        print(f"✓ TaskExecution serialized successfully ({len(serialized)} bytes)")
+    except Exception as e:
+        print(f"✗ TaskExecution serialization failed: {e}")
+        return False
+    
+    # Test deserialization
+    try:
+        deserialized = ProtobufUtils.deserialize_task_execution(serialized)
+        print(f"✓ TaskExecution deserialized successfully")
+        
+        # Verify fields
+        assert deserialized.header.id == execution_id
+        assert deserialized.header.tenant_id == tenant_id
+        assert deserialized.task_type == "test_task"
+        assert deserialized.result.mime_type == "application/json"
+        print(f"✓ TaskExecution field validation passed")
+        
+    except Exception as e:
+        print(f"✗ TaskExecution deserialization failed: {e}")
+        return False
+    
+    return True
+
+
+def test_plan_execution_serialization():
+    """Test PlanExecution serialization and deserialization."""
+    print("\nTesting PlanExecution serialization...")
+    
+    # Create a test PlanExecution
+    execution_id = str(uuid.uuid4())
+    tenant_id = "test-tenant"
+    
+    # Create execution header
+    header = ProtobufUtils.create_execution_header(
+        execution_id=execution_id,
+        tenant_id=tenant_id,
+        status=3,  # SUCCEEDED
+        graph_id="test-graph",
+        lifetime_id="test-lifetime"
+    )
+    
+    # Create plan result
+    plan_result = ProtobufUtils.create_plan_result(
+        next_task_ids=["task1", "task2", "task3"],
+        metadata={"confidence": "high", "reasoning": "test"},
+        confidence=0.85
+    )
+    
+    # Create PlanExecution
+    plan_execution = PlanExecution()
+    plan_execution.header.CopyFrom(header)
+    plan_execution.plan_type = "test_plan"
+    plan_execution.input_task_id = "input_task_123"
+    plan_execution.result.CopyFrom(plan_result)
+    
+    # Test serialization
+    try:
+        serialized = ProtobufUtils.serialize_plan_execution(plan_execution)
+        print(f"✓ PlanExecution serialized successfully ({len(serialized)} bytes)")
+    except Exception as e:
+        print(f"✗ PlanExecution serialization failed: {e}")
+        return False
+    
+    # Test deserialization
+    try:
+        deserialized = ProtobufUtils.deserialize_plan_execution(serialized)
+        print(f"✓ PlanExecution deserialized successfully")
+        
+        # Verify fields
+        assert deserialized.header.id == execution_id
+        assert deserialized.header.tenant_id == tenant_id
+        assert deserialized.plan_type == "test_plan"
+        assert deserialized.input_task_id == "input_task_123"
+        assert len(deserialized.result.next_task_ids) == 3
+        assert abs(deserialized.result.confidence - 0.85) < 0.0001
+        print(f"✓ PlanExecution field validation passed")
+        
+    except Exception as e:
+        print(f"✗ PlanExecution deserialization failed: {e}")
+        return False
+    
+    return True
+
+
+def test_protobuf_utils_validation():
+    """Test protobuf validation utilities."""
+    print("\nTesting protobuf validation...")
+    
+    # Test valid TaskExecution
+    execution_id = str(uuid.uuid4())
+    header = ProtobufUtils.create_execution_header(
+        execution_id=execution_id,
+        tenant_id="test-tenant",
+        status=3
+    )
+    
+    task_execution = TaskExecution()
+    task_execution.header.CopyFrom(header)
+    task_execution.task_type = "test_task"
+    
+    assert ProtobufUtils.validate_task_execution(task_execution)
+    print("✓ Valid TaskExecution validation passed")
+    
+    # Test invalid TaskExecution (missing required fields)
+    invalid_task = TaskExecution()
+    assert not ProtobufUtils.validate_task_execution(invalid_task)
+    print("✓ Invalid TaskExecution validation passed")
+    
+    # Test valid PlanExecution
+    plan_execution = PlanExecution()
+    plan_execution.header.CopyFrom(header)
+    plan_execution.plan_type = "test_plan"
+    
+    assert ProtobufUtils.validate_plan_execution(plan_execution)
+    print("✓ Valid PlanExecution validation passed")
+    
+    # Test invalid PlanExecution (missing required fields)
+    invalid_plan = PlanExecution()
+    assert not ProtobufUtils.validate_plan_execution(invalid_plan)
+    print("✓ Invalid PlanExecution validation passed")
+    
+    return True
+
+
+def test_data_extraction():
+    """Test data extraction utilities."""
+    print("\nTesting data extraction...")
+    
+    # Test task result data extraction
+    task_result = ProtobufUtils.create_task_result(
+        mime_type="application/json",
+        inline_data={"test": "data"}
+    )
+    
+    extracted_data = ProtobufUtils.extract_task_result_data(task_result)
+    assert extracted_data is not None
+    assert extracted_data["type"] == "inline"
+    print("✓ TaskResult data extraction passed")
+    
+    # Test plan result data extraction
+    plan_result = ProtobufUtils.create_plan_result(
+        next_task_ids=["task1", "task2"],
+        metadata={"key": "value"},
+        confidence=0.75
+    )
+    
+    extracted_plan_data = ProtobufUtils.extract_plan_result_data(plan_result)
+    assert len(extracted_plan_data["next_task_ids"]) == 2
+    assert extracted_plan_data["confidence"] == 0.75
+    assert extracted_plan_data["metadata"]["key"] == "value"
+    print("✓ PlanResult data extraction passed")
+    
+    return True
+
+
+def test_json_conversion():
+    """Test JSON conversion utilities."""
+    print("\nTesting JSON conversion...")
+    
+    # Create a test TaskExecution
+    execution_id = str(uuid.uuid4())
+    header = ProtobufUtils.create_execution_header(
+        execution_id=execution_id,
+        tenant_id="test-tenant",
+        status=3
+    )
+    
+    task_execution = TaskExecution()
+    task_execution.header.CopyFrom(header)
+    task_execution.task_type = "test_task"
+    
+    # Test protobuf to JSON-safe dict
+    try:
+        json_dict = ProtobufUtils.to_json_safe_dict(task_execution)
+        assert "header" in json_dict
+        assert "taskType" in json_dict
+        print("✓ Protobuf to JSON-safe dict conversion passed")
+    except Exception as e:
+        print(f"✗ Protobuf to JSON-safe dict conversion failed: {e}")
+        return False
+    
+    # Test JSON-safe dict to protobuf
+    try:
+        reconstructed = ProtobufUtils.from_json_safe_dict(json_dict, TaskExecution)
+        assert reconstructed.header.id == execution_id
+        assert reconstructed.task_type == "test_task"
+        print("✓ JSON-safe dict to protobuf conversion passed")
+    except Exception as e:
+        print(f"✗ JSON-safe dict to protobuf conversion failed: {e}")
+        return False
+    
+    return True
+
+
+def main():
+    """Run all protobuf consistency tests."""
+    print("=" * 60)
+    print("Testing Protobuf Serialization Consistency")
+    print("=" * 60)
+    
+    tests = [
+        test_task_execution_serialization,
+        test_plan_execution_serialization,
+        test_protobuf_utils_validation,
+        test_data_extraction,
+        test_json_conversion
+    ]
+    
+    passed = 0
+    total = len(tests)
+    
+    for test in tests:
+        try:
+            if test():
+                passed += 1
+            else:
+                print(f"✗ Test {test.__name__} failed")
+        except Exception as e:
+            print(f"✗ Test {test.__name__} failed with exception: {e}")
+    
+    print("\n" + "=" * 60)
+    print(f"Test Results: {passed}/{total} tests passed")
+    print("=" * 60)
+    
+    if passed == total:
+        print("✓ All protobuf consistency tests passed!")
+        return 0
+    else:
+        print("✗ Some tests failed. Please check the implementation.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/kafka/ControlPlaneProducer.java
+++ b/services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/kafka/ControlPlaneProducer.java
@@ -79,7 +79,7 @@ public class ControlPlaneProducer {
             );
             
             logger.debug("Sending task execution rejection for tenant {}: {}", tenantId, rejection);
-            kafkaTemplate.send(TopicNames.taskResults(tenantId), rejection);
+            kafkaTemplate.send(TopicNames.controlledTaskExecutions(tenantId), rejection);
             logger.info("Task execution rejection sent for tenant: {}", tenantId);
         } catch (Exception e) {
             logger.error("Failed to send task execution rejection for tenant: {}", tenantId, e);
@@ -103,7 +103,7 @@ public class ControlPlaneProducer {
             );
             
             logger.debug("Sending plan execution rejection for tenant {}: {}", tenantId, rejection);
-            kafkaTemplate.send(TopicNames.planResults(tenantId), rejection);
+            kafkaTemplate.send(TopicNames.controlledPlanExecutions(tenantId), rejection);
             logger.info("Plan execution rejection sent for tenant: {}", tenantId);
         } catch (Exception e) {
             logger.error("Failed to send plan execution rejection for tenant: {}", tenantId, e);

--- a/services/control_plane-java/src/main/resources/application.yml
+++ b/services/control_plane-java/src/main/resources/application.yml
@@ -6,16 +6,16 @@ spring:
     name: control_plane-java
   
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
       group-id: control-plane-group
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.ByteArrayDeserializer
       enable-auto-commit: false
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.ByteArraySerializer
       acks: all
       retries: 3
       batch-size: 16384

--- a/services/data_plane-java/src/main/java/com/pcallahan/agentic/dataplane/entity/PlanExecutionEntity.java
+++ b/services/data_plane-java/src/main/java/com/pcallahan/agentic/dataplane/entity/PlanExecutionEntity.java
@@ -62,10 +62,6 @@ public class PlanExecutionEntity {
     @Column(name = "input_task_id", length = 36)
     private String inputTaskId;
     
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "parameters", columnDefinition = "jsonb")
-    private Map<String, Object> parameters;
-    
     // Result fields
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "result_next_task_ids", columnDefinition = "jsonb")
@@ -202,14 +198,6 @@ public class PlanExecutionEntity {
     
     public void setInputTaskId(String inputTaskId) {
         this.inputTaskId = inputTaskId;
-    }
-    
-    public Map<String, Object> getParameters() {
-        return parameters;
-    }
-    
-    public void setParameters(Map<String, Object> parameters) {
-        this.parameters = parameters;
     }
     
     public List<String> getResultNextTaskIds() {

--- a/services/data_plane-java/src/main/java/com/pcallahan/agentic/dataplane/entity/TaskExecutionEntity.java
+++ b/services/data_plane-java/src/main/java/com/pcallahan/agentic/dataplane/entity/TaskExecutionEntity.java
@@ -58,10 +58,6 @@ public class TaskExecutionEntity {
     @Column(name = "task_type", length = 100, nullable = false)
     private String taskType;
     
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "parameters", columnDefinition = "jsonb")
-    private Map<String, Object> parameters;
-    
     // Foreign key to TaskResult
     @Column(name = "task_result_id", length = 36)
     private String taskResultId;
@@ -174,14 +170,6 @@ public class TaskExecutionEntity {
     
     public void setTaskType(String taskType) {
         this.taskType = taskType;
-    }
-    
-    public Map<String, Object> getParameters() {
-        return parameters;
-    }
-    
-    public void setParameters(Map<String, Object> parameters) {
-        this.parameters = parameters;
     }
     
     public String getTaskResultId() {

--- a/services/data_plane-java/src/main/java/com/pcallahan/agentic/dataplane/service/PersistenceService.java
+++ b/services/data_plane-java/src/main/java/com/pcallahan/agentic/dataplane/service/PersistenceService.java
@@ -1,6 +1,7 @@
 package com.pcallahan.agentic.dataplane.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.pcallahan.agentic.common.ProtobufUtils;
 import com.pcallahan.agentic.dataplane.entity.PlanExecutionEntity;
 import com.pcallahan.agentic.dataplane.entity.TaskExecutionEntity;
@@ -141,7 +142,6 @@ public class PersistenceService {
         
         // Set task-specific fields
         entity.setTaskType(taskExecution.getTaskType());
-        entity.setParameters(convertParameters(taskExecution.getParameters()));
         
         // Set task result ID using the saved entity's ID
         if (savedTaskResult != null) {
@@ -177,7 +177,6 @@ public class PersistenceService {
         // Set plan-specific fields
         entity.setPlanType(planExecution.getPlanType());
         entity.setInputTaskId(planExecution.getInputTaskId());
-        entity.setParameters(convertParameters(planExecution.getParameters()));
         
         // Set result fields
         if (planExecution.hasResult()) {
@@ -229,24 +228,6 @@ public class PersistenceService {
             case EXECUTION_STATUS_FAILED -> PlanExecutionEntity.ExecutionStatus.EXECUTION_STATUS_FAILED;
             default -> PlanExecutionEntity.ExecutionStatus.EXECUTION_STATUS_UNSPECIFIED;
         };
-    }
-    
-    /**
-     * Convert protobuf parameters to Map.
-     * 
-     * @param parameters the protobuf parameters string
-     * @return the parameters map
-     */
-    private Map<String, Object> convertParameters(String parameters) {
-        try {
-            if (parameters == null || parameters.isEmpty()) {
-                return new HashMap<>();
-            }
-            return objectMapper.readValue(parameters, Map.class);
-        } catch (Exception e) {
-            logger.warn("Failed to parse parameters JSON: {}", parameters, e);
-            return new HashMap<>();
-        }
     }
     
     /**

--- a/services/data_plane-java/src/main/resources/application.yml
+++ b/services/data_plane-java/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: data_plane-java
   
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
       group-id: data-plane-group
       auto-offset-reset: earliest
@@ -12,7 +12,7 @@ spring:
       enable-auto-commit: false
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.ByteArraySerializer
       acks: all
       retries: 3
       batch-size: 16384

--- a/services/data_plane-py/data_plane/models.py
+++ b/services/data_plane-py/data_plane/models.py
@@ -59,7 +59,6 @@ class TaskExecution(Base):
     
     # Task-specific fields
     task_type: Mapped[str] = mapped_column(String(255), nullable=False)
-    parameters: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON string
     
     # Result data (stored as JSONB for flexibility)
     result_data: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
@@ -104,7 +103,6 @@ class TaskExecution(Base):
             "status": self.status,
             "edge_taken": self.edge_taken,
             "task_type": self.task_type,
-            "parameters": self.parameters,
             "result_data": self.result_data,
             "result_mime_type": self.result_mime_type,
             "result_size_bytes": self.result_size_bytes,
@@ -144,7 +142,6 @@ class PlanExecution(Base):
     # Plan-specific fields
     plan_type: Mapped[str] = mapped_column(String(255), nullable=False)
     input_task_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    parameters: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON string
     
     # Result data (stored as JSONB for flexibility)
     result_next_task_ids: Mapped[Optional[list[str]]] = mapped_column(JSONB, nullable=True)
@@ -191,7 +188,6 @@ class PlanExecution(Base):
             "edge_taken": self.edge_taken,
             "plan_type": self.plan_type,
             "input_task_id": self.input_task_id,
-            "parameters": self.parameters,
             "result_next_task_ids": self.result_next_task_ids,
             "result_metadata": self.result_metadata,
             "error_message": self.error_message,

--- a/services/standalone-py/agentic/pb/__init__.py
+++ b/services/standalone-py/agentic/pb/__init__.py
@@ -1,0 +1,42 @@
+"""
+Protobuf message imports for agentic microservices.
+
+This module re-exports all protobuf generated classes from locally generated
+protobuf files. Generate the protobuf files using scripts/gen_proto.sh.
+
+This centralizes protobuf imports so microservices don't need to manage
+proto generation individually.
+"""
+
+# Import all protobuf generated classes from local files
+try:
+    from .common_pb2 import ExecutionHeader
+    from .task_pb2 import TaskExecution, TaskResult
+    from .plan_pb2 import PlanExecution, PlanResult
+    from .services_pb2_grpc import (
+        DataPlaneServiceServicer,
+        DataPlaneServiceStub,
+        ControlPlaneServiceServicer,
+        ControlPlaneServiceStub,
+    )
+except ImportError:
+    raise ImportError(
+        "No protobuf files found. Please generate them using:\n"
+        "./scripts/gen_proto.sh"
+    )
+
+__all__ = [
+    # Common protobuf messages
+    "ExecutionHeader",
+    # Task-related protobuf messages
+    "TaskExecution",
+    "TaskResult",
+    # Plan-related protobuf messages
+    "PlanExecution",
+    "PlanResult",
+    # Service definitions
+    "DataPlaneServiceServicer",
+    "DataPlaneServiceStub",
+    "ControlPlaneServiceServicer",
+    "ControlPlaneServiceStub",
+] 

--- a/services/standalone-py/pyproject.toml
+++ b/services/standalone-py/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "structlog==24.1.0",
     "click==8.1.7",
     "aiohttp==3.9.5",
+    "../common-py",
 ]
 
 [project.optional-dependencies]

--- a/services/standalone-py/test_graph_validation.py
+++ b/services/standalone-py/test_graph_validation.py
@@ -25,40 +25,35 @@ from agentic.core.plan import Plan, PlanResult
 class MockTask(Task):
     """Mock task for testing."""
     
-    def __init__(self, tenant_id: str, task_type: str, parameters: dict = None):
+    def __init__(self, tenant_id: str, task_type: str):
         self.tenant_id = tenant_id
         self.task_type = task_type
-        self.parameters = parameters or {}
     
     async def execute(self, lastResult: "PlanResult") -> "TaskResult":
-        return TaskResult(data="mock_result")
+        return TaskResult(data={"result": "mock execution"})
     
     @classmethod
     def deserialize(cls, data):
         return cls(
             tenant_id=data['tenant_id'],
-            task_type=data['task_type'],
-            parameters=data.get('parameters', {})
+            task_type=data['task_type']
         )
     
     @classmethod
     def from_protobuf(cls, proto):
         """Create a MockTask from a protobuf message."""
-        import json
         return cls(
             tenant_id=proto.header.tenant_id,
-            task_type=proto.task_type,
-            parameters=json.loads(proto.parameters) if proto.parameters else {}
+            task_type=proto.task_type
         )
 
 
 class MockPlan(Plan):
     """Mock plan for testing."""
     
-    def __init__(self, tenant_id: str, plan_type: str, parameters: dict = None):
+    def __init__(self, tenant_id: str, plan_type: str):
         self.tenant_id = tenant_id
         self.plan_type = plan_type
-        self.parameters = parameters or {}
     
     async def plan(self, lastResult: "TaskResult") -> "PlanResult":
         return PlanResult(next_task_ids=["task2"])
@@ -67,18 +62,15 @@ class MockPlan(Plan):
     def deserialize(cls, data):
         return cls(
             tenant_id=data['tenant_id'],
-            plan_type=data['plan_type'],
-            parameters=data.get('parameters', {})
+            plan_type=data['plan_type']
         )
     
     @classmethod
     def from_protobuf(cls, proto):
         """Create a MockPlan from a protobuf message."""
-        import json
         return cls(
             tenant_id=proto.header.tenant_id,
-            plan_type=proto.plan_type,
-            parameters=json.loads(proto.parameters) if proto.parameters else {}
+            plan_type=proto.plan_type
         )
 
 

--- a/services/standalone-py/test_standalone_integration.py
+++ b/services/standalone-py/test_standalone_integration.py
@@ -72,7 +72,6 @@ async def test_standalone_integration():
     task_execution.header.status = common_pb2.EXECUTION_STATUS_PENDING
     task_execution.header.created_at = datetime.utcnow().isoformat()
     task_execution.task_type = "test_task"
-    task_execution.parameters = json.dumps({"test_param": "test_value"})
     
     # Publish to task-executions queue
     task_executions_topic = f"task-executions_{tenant_id}"
@@ -94,7 +93,6 @@ async def test_standalone_integration():
     plan_execution.header.status = common_pb2.EXECUTION_STATUS_PENDING
     plan_execution.header.created_at = datetime.utcnow().isoformat()
     plan_execution.plan_type = "test_plan"
-    plan_execution.parameters = json.dumps({"plan_param": "plan_value"})
     plan_execution.input_task_id = task_execution.header.id
     
     # Publish to plan-executions queue


### PR DESCRIPTION
…olled-task-executions-{tenantId}`.

Rename the kakfa topic `plan-results-{tenantId}` to be `controlled-plan-executions-{tenantId}`. Instead of publishing TaskResults and PlanResults, respectively on those topics, publish TaskExecutions and PlanExecutions from the ControlPlane.

Update any documentation

Update any related interfaces that take TaskResults to take TaskExecutions and update any related interfaces that take PlanResults to take PlanExecutions.  Update any documentation

Update code interacting with this topic.
Update documents to reflect this name change

Plan (Traycer):

I have created the following plan after thorough exploration and analysis of the codebase. Follow the below plan verbatim. Trust the files and references. Do not re-verify what's written in the plan. Explore only when absolutely necessary. First implement all the proposed file changes and then I'll review all the changes together at the end.

### Observations

The system uses a well-structured microservices architecture with centralized topic naming utilities and consistent patterns. All topic references are properly abstracted through utility classes rather than hardcoded strings. The ControlPlane currently extracts TaskResult/PlanResult from execution messages before publishing, but the infrastructure already supports publishing full execution messages. Python services use JSON serialization while Java uses protobuf, creating an inconsistency that should be addressed.

### Approach

I'll systematically rename the Kafka topics from `task-results-{tenantId}` and `plan-results-{tenantId}` to `controlled-task-executions-{tenantId}` and `controlled-plan-executions-{tenantId}`, and refactor the ControlPlane to publish full TaskExecution/PlanExecution messages instead of extracted TaskResult/PlanResult messages. This requires coordinated changes across Java services, Python services, configuration files, and documentation. The existing ProtobufUtils already has the necessary serialization methods, which simplifies implementation.

### Reasoning

I analyzed the codebase structure and found all references to the current topic names across Java and Python services. I examined the ControlPlane's current message extraction and publishing logic, the executor services' consumption patterns, Python service implementations, protobuf utilities, configuration files, and documentation. I discovered that ProtobufUtils already has the required serialization methods and that Python services currently use JSON instead of protobuf, requiring additional changes for consistency.

## Mermaid Diagram

sequenceDiagram
    participant TE as TaskExecutor
    participant DP as DataPlane
    participant CP as ControlPlane
    participant PE as PlanExecutor
    participant K as Kafka Topics

    Note over TE,PE: NEW: Full Execution Message Flow

    %% Task Execution Flow with New Topics and Message Types
    TE->>K: TaskExecution (protobuf)<br/>→ task-executions-{tenantId}
    DP->>K: Consume TaskExecution
    DP->>DP: Persist TaskExecutionEntity
    DP->>K: Forward TaskExecution<br/>→ persisted-task-executions-{tenantId}

    CP->>K: Consume TaskExecution
    CP->>CP: Evaluate Guardrails
    Note over CP: NEW: Publish FULL TaskExecution<br/>(not just TaskResult)
    CP->>K: Publish TaskExecution (protobuf)<br/>→ controlled-task-executions-{tenantId}<br/>(RENAMED TOPIC)

    PE->>K: Consume TaskExecution<br/>from controlled-task-executions-{tenantId}
    PE->>PE: Extract TaskResult from TaskExecution.result
    PE->>PE: Execute Planning Logic
    PE->>K: PlanExecution (protobuf)<br/>→ plan-executions-{tenantId}

    %% Plan Execution Flow with New Topics and Message Types
    DP->>K: Consume PlanExecution
    DP->>DP: Persist PlanExecutionEntity
    DP->>K: Forward PlanExecution<br/>→ persisted-plan-executions-{tenantId}

    CP->>K: Consume PlanExecution
    CP->>CP: Evaluate Guardrails
    Note over CP: NEW: Publish FULL PlanExecution<br/>(not just PlanResult)
    CP->>K: Publish PlanExecution (protobuf)<br/>→ controlled-plan-executions-{tenantId}<br/>(RENAMED TOPIC)

    TE->>K: Consume PlanExecution<br/>from controlled-plan-executions-{tenantId}
    TE->>TE: Extract PlanResult from PlanExecution.result
    TE->>TE: Execute Next Tasks

    Note over TE,PE: Key Changes:<br/>1. Topics renamed to controlled-*-executions<br/>2. Full execution messages published<br/>3. Consumers extract results from executions

## Proposed File Changes

### services/common-java/src/main/java/com/pcallahan/agentic/common/TopicNames.java(MODIFY)

Rename the `taskResults()` method to `controlledTaskExecutions()` and update its return value from `"task-results-" + tenantId` to `"controlled-task-executions-" + tenantId`. Rename the `planResults()` method to `controlledPlanExecutions()` and update its return value from `"plan-results-" + tenantId` to `"controlled-plan-executions-" + tenantId`. Update the class-level documentation on lines 12-13 to replace `task-results, plan-results` with `controlled-task-executions, controlled-plan-executions` in the list of topic prefixes. Update the `isValidTopicName()` method to check for `"controlled-task-executions"` and `"controlled-plan-executions"` instead of `"task-results"` and `"plan-results"`. Mark the old methods as `@Deprecated` for backward compatibility during transition.

### services/common-java/src/main/java/com/pcallahan/agentic/common/KafkaTopicPatterns.java(MODIFY)

References:

- services/common-java/src/main/java/com/pcallahan/agentic/common/TopicNames.java(MODIFY)

Rename the `taskResults` field to `controlledTaskExecutions` and update its default value from `"task-results-.*"` to `"controlled-task-executions-.*"`. Rename the `planResults` field to `controlledPlanExecutions` and update its default value from `"plan-results-.*"` to `"controlled-plan-executions-.*"`. Rename the getter method from `getTaskResultsPattern()` to `getControlledTaskExecutionsPattern()`. Rename the getter method from `getPlanResultsPattern()` to `getControlledPlanExecutionsPattern()`. Rename the setter methods accordingly and update their parameter names. Update the log messages to reference the new pattern names. Update the `getAllPatterns()` method to use `"controlledTaskExecutions"` and `"controlledPlanExecutions"` as keys instead of `"taskResults"` and `"planResults"`. Update the `validatePatterns()` method to check the new field names and update error messages accordingly.

### services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/kafka/ExecutorProducer.java(MODIFY)

References:

- services/common-java/src/main/java/com/pcallahan/agentic/common/TopicNames.java(MODIFY)

Replace the `publishTaskResult(String tenantId, TaskResult taskResult)` method with `publishTaskExecution(String tenantId, TaskExecution taskExecution)`. Update the method to use `TopicNames.controlledTaskExecutions(tenantId)` for topic naming and `ProtobufUtils.serializeTaskExecution(taskExecution)` for serialization. Replace the `publishPlanResult(String tenantId, PlanResult planResult)` method with `publishPlanExecution(String tenantId, PlanExecution planExecution)`. Update the method to use `TopicNames.controlledPlanExecutions(tenantId)` for topic naming and `ProtobufUtils.serializePlanExecution(planExecution)` for serialization. Update the class-level documentation on lines 20-22 to reflect publishing TaskExecution and PlanExecution messages to controlled-task-executions and controlled-plan-executions topics. Update method parameter types, variable names, and log messages throughout to reflect the new message types.

### services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/service/ExecutionRouter.java(MODIFY)

References:

- services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/kafka/ExecutorProducer.java(MODIFY)

In the `routeTaskExecution()` method, remove the call to `extractTaskResult(taskExecution)` and directly pass the `taskExecution` to the updated `executorProducer.publishTaskExecution(tenantId, taskExecution)` method. In the `routePlanExecution()` method, remove the call to `extractPlanResult(planExecution)` and directly pass the `planExecution` to the updated `executorProducer.publishPlanExecution(tenantId, planExecution)` method. Delete the `extractTaskResult(TaskExecution taskExecution)` method entirely as it's no longer needed. Delete the `extractPlanResult(PlanExecution planExecution)` method entirely as it's no longer needed. Update the class-level documentation on lines 17-19 to reflect that the service now routes full TaskExecution and PlanExecution messages instead of extracting and routing just the result portions. Update log messages to reflect publishing full execution messages.

### services/plan_executor-java/src/main/java/com/pcallahan/agentic/planexecutor/kafka/TaskResultListener.java(MODIFY)

References:

- services/common-java/src/main/java/com/pcallahan/agentic/common/KafkaTopicPatterns.java(MODIFY)

Update the `@KafkaListener` annotation to use `"#{@kafkaTopicPatterns.controlledTaskExecutionsPattern}"` instead of `"#{@kafkaTopicPatterns.taskResultsPattern}"`. Update the `groupId` to `"plan-executor-controlled-task-executions"` instead of `"plan-executor-task-results"`. Change the deserialization call from `ProtobufUtils.deserializeTaskResult(record.value())` to `ProtobufUtils.deserializeTaskExecution(record.value())`. Update the method parameter type from `TaskResult taskResult` to `TaskExecution taskExecution`. Update the service call to `planExecutorService.executePlansFromTaskExecution(taskExecution, tenantId)` instead of the old method name. Update the class-level documentation to reflect consuming TaskExecution messages from controlled-task-executions topics. Update all variable names, types, and log messages from `TaskResult` to `TaskExecution`. Update the method name from `handleTaskResult` to `handleTaskExecution` for consistency.

### services/plan_executor-java/src/main/java/com/pcallahan/agentic/planexecutor/service/PlanExecutorService.java(MODIFY)

References:

- services/plan_executor-java/src/main/java/com/pcallahan/agentic/planexecutor/kafka/TaskResultListener.java(MODIFY)

Rename the `executePlansFromTaskResult(TaskResult taskResult, String tenantId)` method to `executePlansFromTaskExecution(TaskExecution taskExecution, String tenantId)`. Update the error checking logic to use `taskExecution.getResult().getErrorMessage()` instead of directly accessing `taskResult.getErrorMessage()`. Update the `cacheTaskResult(TaskResult taskResult)` method to `cacheTaskExecution(TaskExecution taskExecution)` and cache `taskExecution.getResult()` by its ID, or modify the cache access pattern to work with TaskExecution objects. Update the `PlanHandler.execute()` interface signature to accept `TaskExecution` instead of `TaskResult`. In the `DefaultPlanHandler.execute()` method, extract the `TaskResult` from the `TaskExecution` parameter using `taskExecution.getResult()` and then proceed with existing logic. Update the `extractPlanType()` method to accept `TaskExecution` and extract the plan type from `taskExecution.getResult()`. Update all data extraction logic throughout the class to use `taskExecution.getResult()` accessor pattern. Update class-level documentation to reflect consuming TaskExecution messages instead of TaskResult messages.

### services/task_executor-java/src/main/java/com/pcallahan/agentic/taskexecutor/kafka/PlanResultListener.java(MODIFY)

References:

- services/common-java/src/main/java/com/pcallahan/agentic/common/KafkaTopicPatterns.java(MODIFY)

Update the `@KafkaListener` annotation to use `"#{@kafkaTopicPatterns.controlledPlanExecutionsPattern}"` instead of `"#{@kafkaTopicPatterns.planResultsPattern}"`. Update the `groupId` to `"task-executor-controlled-plan-executions"` instead of `"task-executor-plan-results"`. Change the deserialization call from `ProtobufUtils.deserializePlanResult(record.value())` to `ProtobufUtils.deserializePlanExecution(record.value())`. Update the method parameter type from `PlanResult planResult` to `PlanExecution planExecution`. Update the service call to `taskExecutorService.executeTasksFromPlanExecution(planExecution, tenantId)` instead of the old method name. Update the class-level documentation to reflect consuming PlanExecution messages from controlled-plan-executions topics. Update all variable names, types, and log messages from `PlanResult` to `PlanExecution`. Update the method name from `handlePlanResult` to `handlePlanExecution` for consistency.

### services/task_executor-java/src/main/java/com/pcallahan/agentic/taskexecutor/service/TaskExecutorService.java(MODIFY)

References:

- services/task_executor-java/src/main/java/com/pcallahan/agentic/taskexecutor/kafka/PlanResultListener.java(MODIFY)

Rename the `executeTasksFromPlan(PlanResult planResult, String tenantId)` method to `executeTasksFromPlanExecution(PlanExecution planExecution, String tenantId)`. Update the error checking logic to use `planExecution.getResult().getErrorMessage()` instead of directly accessing `planResult.getErrorMessage()`. Update the task ID extraction to use `planExecution.getResult().getNextTaskIdsList()` instead of `planResult.getNextTaskIdsList()`. Update the `executeTask()` method signature to accept `PlanExecution` instead of `PlanResult`. Update the `TaskHandler.execute()` interface signature to accept `PlanExecution` instead of `PlanResult`. In the `DefaultTaskHandler.execute()` method, extract the `PlanResult` from the `PlanExecution` parameter using `planExecution.getResult()` and then proceed with existing logic. Update the `extractTaskType()` method to work with `PlanExecution` if it uses plan data. Update all data extraction logic throughout the class to use `planExecution.getResult()` accessor pattern. Update class-level documentation to reflect consuming PlanExecution messages instead of PlanResult messages.

### services/plan_executor-java/src/main/resources/application.yml(MODIFY)

Update the `kafka.topic-patterns.task-results` configuration key to `kafka.topic-patterns.controlled-task-executions` and change its pattern value from `"task-results-.*"` to `"controlled-task-executions-.*"`.

### services/task_executor-java/src/main/resources/application.yml(MODIFY)

Update the `kafka.topic-patterns.plan-results` configuration key to `kafka.topic-patterns.controlled-plan-executions` and change its pattern value from `"plan-results-.*"` to `"controlled-plan-executions-.*"`.

### services/common-py/agentic_common/kafka_utils.py(MODIFY)

Rename the function `get_task_results_topic(tenant_id: str)` to `get_controlled_task_executions_topic(tenant_id: str)` and update its return value from `f"task-results_{tenant_id}"` to `f"controlled-task-executions_{tenant_id}"`. Rename the function `get_plan_results_topic(tenant_id: str)` to `get_controlled_plan_executions_topic(tenant_id: str)` and update its return value to `f"controlled-plan-executions_{tenant_id}"` (fixing any inconsistent prefixes like `tenant_tenant_`). Update the function docstrings to reflect the new topic names. Mark the old functions as deprecated for backward compatibility during transition.

### services/common-py/agentic_common/__init__.py(MODIFY)

References:

- services/common-py/agentic_common/kafka_utils.py(MODIFY)

Update the import statement to import the new function names `get_controlled_task_executions_topic` and `get_controlled_plan_executions_topic` instead of the old ones. Update the `__all__` export list to include the new function names instead of `"get_task_results_topic"` and `"get_plan_results_topic"`.

### services/control_plane-py/control_plane/kafka_producer.py(MODIFY)

References:

- services/common-py/agentic_common/kafka_utils.py(MODIFY)

Replace the `publish_task_result()` method with `publish_task_execution()` that accepts a TaskExecution protobuf object instead of a dict. Update the method to serialize the TaskExecution using protobuf serialization (`.SerializeToString()`) instead of JSON. Update the topic name to use the new `get_controlled_task_executions_topic(tenant_id)` function. Replace the `publish_plan_result()` method with `publish_plan_execution()` that accepts a PlanExecution protobuf object. Update the method to serialize the PlanExecution using protobuf serialization instead of JSON. Update the topic name to use the new `get_controlled_plan_executions_topic(tenant_id)` function. Update the `publish_execution_result()` method to dispatch to the new methods based on execution type. Update imports to include the protobuf classes from `agentic_common.pb`. Update all method documentation and log messages to reflect publishing full execution messages instead of result messages.

### services/control_plane-py/control_plane/router.py(MODIFY)

References:

- services/control_plane-py/control_plane/kafka_producer.py(MODIFY)

Update the `route_task_result()` method to `route_task_execution()` and modify it to route full TaskExecution messages instead of extracted TaskResult. Update the `route_plan_result()` method to `route_plan_execution()` and modify it to route full PlanExecution messages instead of extracted PlanResult. Update the routing logic to use the new topic names via the updated kafka_utils functions. Update the `route_execution()` method to handle the new message types. Update all method documentation and comments to reflect routing full execution messages. Update imports to use the new topic naming functions.

### services/standalone-py/agentic/executors/task_executor.py(MODIFY)

References:

- services/common-py/agentic_common/kafka_utils.py(MODIFY)

Update the `_consumer_loop()` method to subscribe to the new `controlled-task-executions_{tenant_id}` topic using the updated `get_controlled_task_executions_topic()` function. Update the `_process_task_result()` method to `_process_task_execution()` and modify it to consume and deserialize TaskExecution protobuf messages instead of JSON TaskResult messages. Update the message processing logic to extract the TaskResult from the TaskExecution using `.result` field and then proceed with existing task execution logic. Update imports to use the new topic naming functions and protobuf classes. Update all method documentation and log messages to reflect consuming TaskExecution messages instead of TaskResult messages.

### services/standalone-py/agentic/executors/plan_executor.py(MODIFY)

References:

- services/common-py/agentic_common/kafka_utils.py(MODIFY)

Update the `_consumer_loop()` method to subscribe to the new `controlled-plan-executions_{tenant_id}` topic using the updated `get_controlled_plan_executions_topic()` function. Update the `_process_plan_result()` method to `_process_plan_execution()` and modify it to consume and deserialize PlanExecution protobuf messages instead of JSON PlanResult messages. Update the message processing logic to extract the PlanResult from the PlanExecution using `.result` field and then proceed with existing plan execution logic. Update imports to use the new topic naming functions and protobuf classes. Update all method documentation and log messages to reflect consuming PlanExecution messages instead of PlanResult messages.

### services/control_plane-py/control_plane/kafka_consumer.py(MODIFY)

Update the module docstring to reference `controlled-task-executions_*` and `controlled-plan-executions_*` instead of the old topic patterns. Update any topic pattern matching logic to use the new topic names. Update the message processing logic to handle the routing of full execution messages instead of extracted results. Update imports to use the new topic naming functions.

### services/executor_old-py/executor/kafka_consumer.py(MODIFY)

Update the module docstring to reference `controlled-task-executions_*` and `controlled-plan-executions_*` instead of `task-results_*` and `plan-results_*` topics. Update the topic subscription patterns to use the new topic names. Update the topic checking logic in `_process_message()` to check for `controlled-task-executions_` and `controlled-plan-executions_` prefixes instead of the old ones. Update the message dispatching logic to handle TaskExecution and PlanExecution messages instead of TaskResult and PlanResult messages.

### docs/DataFlow.md(MODIFY)

Update the mermaid architecture diagram on lines 38-52 to replace `task-results-{}` with `controlled-task-executions-{}` and `plan-results-{}` with `controlled-plan-executions-{}`. Update the Task Execution Flow sequence diagram on lines 72-83 to show ControlPlane publishing TaskExecution to `controlled-task-executions-{tenantId}` instead of TaskResult to `task-results-{tenantId}`. Update the Plan Execution Flow sequence diagram on lines 97-108 to show ControlPlane publishing PlanExecution to `controlled-plan-executions-{tenantId}` instead of PlanResult to `plan-results-{tenantId}`. Update the "Result Topics" section on lines 121-123 to "Control Topics" and list the new topic names. Update the Kafka Topics section on lines 187-193 to use the new topic names. Update the ControlPlane responsibilities description on lines 145-149 to reflect publishing full TaskExecution and PlanExecution messages instead of extracted TaskResult and PlanResult messages. Update all sequence diagram steps and descriptions to reflect the new message flow.

### docs/TENANT_AWARE_KAFKA.md(MODIFY)

Update lines 23-24 to replace `task-results-{tenantId}` and `plan-results-{tenantId}` with `controlled-task-executions-{tenantId}` and `controlled-plan-executions-{tenantId}` in the supported topic types list. Update the configuration examples on lines 39-42 to use the new topic pattern names and values. Update any @KafkaListener examples to reference the new pattern names. Update the groupId examples to use the new topic-based naming convention. Update all topic naming conventions and best practices sections to reflect the new naming scheme.

### docs/TENANT_AWARE_KAFKA_EXAMPLE.md(MODIFY)

Update the example topic patterns and configuration to use `controlled-task-executions-.*` and `controlled-plan-executions-.*` instead of the old patterns. Update the example Kafka topic creation commands to create topics like `controlled-task-executions-tenant-a` and `controlled-plan-executions-tenant-b` instead of the old topic names. Update all example configurations and code snippets to reflect the new topic naming convention.

### docs/DEPLOYMENT.md(MODIFY)

Update the "Infrastructure Services" section on lines 67-68 to list `controlled-task-executions` and `controlled-plan-executions` as Kafka topics instead of `task-results` and `plan-results`. Ensure the topic list uses the tenant-specific pattern format (`controlled-task-executions-{tenantId}`, `controlled-plan-executions-{tenantId}`) for consistency.

### services/common-java/pom.xml(MODIFY)

Increment the version number of the common-java library to reflect the API changes in TopicNames and KafkaTopicPatterns classes. This ensures that all dependent services will use the updated topic naming methods and patterns.

### services/data_plane-java/pom.xml(MODIFY)

References:

- services/common-java/pom.xml(MODIFY)

Update the dependency version for common-java to match the new version that includes the updated topic naming methods and patterns. This ensures the DataPlane service can work with the new topic names.

### services/control_plane-java/pom.xml(MODIFY)

References:

- services/common-java/pom.xml(MODIFY)

Update the dependency version for common-java to match the new version that includes the updated topic naming methods and patterns. This ensures the ControlPlane service can work with the new topic names and message types.

### services/plan_executor-java/pom.xml(MODIFY)

References:

- services/common-java/pom.xml(MODIFY)

Update the dependency version for common-java to match the new version that includes the updated topic naming methods and patterns. This ensures the PlanExecutor service can work with the new topic names and consume TaskExecution messages.

### services/task_executor-java/pom.xml(MODIFY)

References:

- services/common-java/pom.xml(MODIFY)

Update the dependency version for common-java to match the new version that includes the updated topic naming methods and patterns. This ensures the TaskExecutor service can work with the new topic names and consume PlanExecution messages.