### PR TITLE
Rename controlled-plan-executions topic to task-inputs and update code

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -64,7 +64,7 @@ docker-compose -f docker-compose.yml -f docker-compose.override.yml down
 
 #### Kafka (Port 9092)
 - **Purpose**: Message broker for inter-service communication
-- **Topics**: task-executions, plan-executions, plan-inputs, controlled-plan-executions
+- **Topics**: task-executions, plan-executions, persisted-task-executions,persisted-plan-executions, plan-inputs, task-inputs
 - **Management**: Kafka UI at http://localhost:8080
 
 #### PostgreSQL (Port 5432)

--- a/docs/TENANT_AWARE_KAFKA.md
+++ b/docs/TENANT_AWARE_KAFKA.md
@@ -23,7 +23,7 @@ All topics follow the pattern: `{message-type}-{tenant-id}`
 - `persisted-task-executions-{tenantId}` - Persisted task execution messages
 - `persisted-plan-executions-{tenantId}` - Persisted plan execution messages
 - `plan-inputs-{tenantId}` - Plan input messages
-- `controlled-plan-executions-{tenantId}` - Controlled plan execution messages
+- `task-inputs-{tenantId}` - Task input messages
 - `task-executions-dlq-{tenantId}` - Task execution dead letter queue
 - `plan-executions-dlq-{tenantId}` - Plan execution dead letter queue
 
@@ -39,7 +39,7 @@ kafka:
     persisted-task-executions: "persisted-task-executions-.*"
     persisted-plan-executions: "persisted-plan-executions-.*"
     plan-inputs: "plan-inputs-.*"
-    controlled-plan-executions: "controlled-plan-executions-.*"
+    task-inputs: "task-inputs-.*"
     task-executions-dlq: "task-executions-dlq-.*"
     plan-executions-dlq: "plan-executions-dlq-.*"
 ```
@@ -329,6 +329,10 @@ kafka:
 - Set up alerts for tenant-specific issues
 - Monitor tenant message processing delays
 - Alert on tenant-specific error thresholds
+
+## TaskInput Message Flow
+
+TaskExecutors receive TaskInput messages (the upstream PlanExecution). This enables more granular task execution control and better separation of concerns between planning and execution phases.
 
 ## Future Enhancements
 

--- a/services/admin-java/src/main/java/com/pcallahan/agentic/admin/service/KafkaTopicManager.java
+++ b/services/admin-java/src/main/java/com/pcallahan/agentic/admin/service/KafkaTopicManager.java
@@ -124,7 +124,7 @@ public class KafkaTopicManager {
             TopicNames.persistedTaskExecutions(tenantId),
             TopicNames.persistedPlanExecutions(tenantId),
             TopicNames.planInputs(tenantId),
-            TopicNames.controlledPlanExecutions(tenantId)
+            TopicNames.taskInputs(tenantId)
         );
     }
     

--- a/services/common-java/src/main/java/com/pcallahan/agentic/common/KafkaTopicPatterns.java
+++ b/services/common-java/src/main/java/com/pcallahan/agentic/common/KafkaTopicPatterns.java
@@ -26,7 +26,7 @@ public class KafkaTopicPatterns {
     private String persistedTaskExecutions = "persisted-task-executions-.*";
     private String persistedPlanExecutions = "persisted-plan-executions-.*";
     private String planInputs = "plan-inputs-.*";
-    private String controlledPlanExecutions = "controlled-plan-executions-.*";
+    private String taskInputs = "task-inputs-.*";
     
     // Getters and setters
     public String getTaskExecutionsPattern() {
@@ -74,13 +74,13 @@ public class KafkaTopicPatterns {
         logger.debug("Set plan inputs pattern: {}", planInputs);
     }
     
-    public String getControlledPlanExecutionsPattern() {
-        return controlledPlanExecutions;
+    public String getTaskInputsPattern() {
+        return taskInputs;
     }
     
-    public void setControlledPlanExecutions(String controlledPlanExecutions) {
-        this.controlledPlanExecutions = controlledPlanExecutions;
-        logger.debug("Set controlled plan executions pattern: {}", controlledPlanExecutions);
+    public void setTaskInputs(String taskInputs) {
+        this.taskInputs = taskInputs;
+        logger.debug("Set task inputs pattern: {}", taskInputs);
     }
     
     /**
@@ -95,7 +95,7 @@ public class KafkaTopicPatterns {
             "persistedTaskExecutions", persistedTaskExecutions,
             "persistedPlanExecutions", persistedPlanExecutions,
             "planInputs", planInputs,
-            "controlledPlanExecutions", controlledPlanExecutions
+            "taskInputs", taskInputs
         );
     }
     
@@ -132,8 +132,8 @@ public class KafkaTopicPatterns {
             isValid = false;
         }
         
-        if (controlledPlanExecutions == null || controlledPlanExecutions.isEmpty()) {
-            logger.error("Controlled plan executions pattern is not configured");
+        if (taskInputs == null || taskInputs.isEmpty()) {
+            logger.error("Task inputs pattern is not configured");
             isValid = false;
         }
         

--- a/services/common-java/src/main/java/com/pcallahan/agentic/common/ProtobufUtils.java
+++ b/services/common-java/src/main/java/com/pcallahan/agentic/common/ProtobufUtils.java
@@ -4,6 +4,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.arl.proto.model.Task.TaskExecution;
 import io.arl.proto.model.Plan.PlanExecution;
 import io.arl.proto.model.Plan.PlanInput;
+import io.arl.proto.model.Plan.TaskInput;
 import io.arl.proto.model.Task.TaskResult;
 import io.arl.proto.model.Plan.PlanResult;
 import org.slf4j.Logger;
@@ -131,6 +132,44 @@ public class ProtobufUtils {
             return PlanExecution.parseFrom(data);
         } catch (InvalidProtocolBufferException e) {
             logger.error("Failed to deserialize PlanExecution from byte array: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+    
+    /**
+     * Serialize a TaskInput protobuf message to byte array.
+     * 
+     * @param taskInput the TaskInput message to serialize
+     * @return byte array representation, or null if serialization fails
+     */
+    public static byte[] serializeTaskInput(TaskInput taskInput) {
+        try {
+            if (taskInput == null) {
+                logger.warn("Cannot serialize null TaskInput");
+                return null;
+            }
+            return taskInput.toByteArray();
+        } catch (Exception e) {
+            logger.error("Failed to serialize TaskInput: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+    
+    /**
+     * Deserialize a byte array to TaskInput protobuf message.
+     * 
+     * @param data the byte array to deserialize
+     * @return TaskInput message, or null if deserialization fails
+     */
+    public static TaskInput deserializeTaskInput(byte[] data) {
+        try {
+            if (data == null || data.length == 0) {
+                logger.warn("Cannot deserialize null or empty byte array to TaskInput");
+                return null;
+            }
+            return TaskInput.parseFrom(data);
+        } catch (InvalidProtocolBufferException e) {
+            logger.error("Failed to deserialize TaskInput from byte array: {}", e.getMessage(), e);
             return null;
         }
     }

--- a/services/common-java/src/main/java/com/pcallahan/agentic/common/TopicNames.java
+++ b/services/common-java/src/main/java/com/pcallahan/agentic/common/TopicNames.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * 
  * The system uses only tenant-specific topics with the pattern {prefix}-{tenantId}
  * where prefix is one of: task-executions, plan-executions, persisted-task-executions, 
- * persisted-plan-executions, plan-inputs, controlled-plan-executions.
+ * persisted-plan-executions, plan-inputs, task-inputs.
  */
 public class TopicNames {
     
@@ -71,20 +71,20 @@ public class TopicNames {
     }
     
     /**
-     * Generate controlled plan executions topic name for a tenant.
+     * Generate task inputs topic name for a tenant.
      * 
      * @param tenantId the tenant identifier
-     * @return topic name in format: controlled-plan-executions-{tenantId}
+     * @return topic name in format: task-inputs-{tenantId}
      */
-    public static String controlledPlanExecutions(String tenantId) {
-        return "controlled-plan-executions-" + tenantId;
+    public static String taskInputs(String tenantId) {
+        return "task-inputs-" + tenantId;
     }
     
 
     
     /**
      * Extract tenant ID from a topic name by splitting on the last hyphen.
-     * Handles patterns like task-executions-{tenantId}, controlled-plan-executions-{tenantId}, etc.
+     * Handles patterns like task-executions-{tenantId}, etc.
      * 
      * @param topicName the full topic name
      * @return the tenant ID, or null if not found
@@ -207,8 +207,8 @@ public class TopicNames {
                        prefix.equals("plan-executions") || 
                        prefix.equals("persisted-task-executions") || 
                        prefix.equals("persisted-plan-executions") ||
-                       prefix.equals("controlled-task-executions") ||
-                       prefix.equals("plan-inputs");
+                       prefix.equals("plan-inputs") ||
+                       prefix.equals("task-inputs");
             }
         }
         

--- a/services/common-py/agentic_common/kafka_utils.py
+++ b/services/common-py/agentic_common/kafka_utils.py
@@ -22,12 +22,6 @@ def get_plan_inputs_topic(tenant_id: str) -> str:
     return f"plan-inputs-{tenant_id}"
 
 
-def get_controlled_task_executions_topic(tenant_id: str) -> str:
-    """Get the controlled task executions topic name for a tenant.
-    
-    @deprecated Use get_plan_inputs_topic instead
-    """
-    return f"controlled-task-executions-{tenant_id}"
 
 
 def get_plan_execution_topic(tenant_id: str) -> str:
@@ -35,9 +29,6 @@ def get_plan_execution_topic(tenant_id: str) -> str:
     return f"plan-executions_{tenant_id}"
 
 
-def get_controlled_plan_executions_topic(tenant_id: str) -> str:
-    """Get the controlled plan executions topic name for a tenant."""
-    return f"controlled-plan-executions-{tenant_id}"
 
 
 def get_persisted_task_executions_topic(tenant_id: str) -> str:
@@ -64,6 +55,11 @@ def get_plan_results_topic(tenant_id: str) -> str:
     @deprecated Use get_controlled_plan_executions_topic instead
     """
     return f"plan-results_{tenant_id}"
+
+
+def get_task_inputs_topic(tenant_id: str) -> str:
+    """Get the task inputs topic name for a tenant."""
+    return f"task-inputs-{tenant_id}"
 
 
 async def create_kafka_producer(

--- a/services/common-py/agentic_common/pb_utils.py
+++ b/services/common-py/agentic_common/pb_utils.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, Dict, Optional, Union
 from datetime import datetime
 
-from .pb import TaskExecution, PlanExecution, PlanInput, TaskResult, PlanResult, ExecutionHeader
+from .pb import TaskExecution, PlanExecution, PlanInput, TaskInput, TaskResult, PlanResult, ExecutionHeader
 
 
 class ProtobufUtils:
@@ -99,6 +99,46 @@ class ProtobufUtils:
             return plan_input
         except Exception as e:
             raise ValueError(f"Failed to deserialize PlanInput: {e}")
+    
+    @staticmethod
+    def serialize_task_input(task_input: TaskInput) -> bytes:
+        """
+        Serialize TaskInput protobuf message to bytes.
+        
+        Args:
+            task_input: TaskInput protobuf message
+            
+        Returns:
+            Serialized bytes
+            
+        Raises:
+            ValueError: If serialization fails
+        """
+        try:
+            return task_input.SerializeToString()
+        except Exception as e:
+            raise ValueError(f"Failed to serialize TaskInput: {e}")
+    
+    @staticmethod
+    def deserialize_task_input(message_bytes: bytes) -> TaskInput:
+        """
+        Deserialize bytes to TaskInput protobuf message.
+        
+        Args:
+            message_bytes: Serialized protobuf message bytes
+            
+        Returns:
+            TaskInput protobuf message
+            
+        Raises:
+            ValueError: If deserialization fails
+        """
+        try:
+            task_input = TaskInput()
+            task_input.ParseFromString(message_bytes)
+            return task_input
+        except Exception as e:
+            raise ValueError(f"Failed to deserialize TaskInput: {e}")
     
     @staticmethod
     def serialize_plan_execution(plan_execution: PlanExecution) -> bytes:

--- a/services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/service/TaskLookupService.java
+++ b/services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/service/TaskLookupService.java
@@ -1,0 +1,55 @@
+package com.pcallahan.agentic.controlplane.service;
+
+import com.pcallahan.agentic.graph.model.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Service for looking up task metadata by task names.
+ * 
+ * This service is responsible for retrieving task information from the graph/database
+ * based on task names. Currently implemented as a stub that returns mock data.
+ * 
+ * TODO: Replace with actual graph/database lookup logic
+ */
+@Service
+public class TaskLookupService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(TaskLookupService.class);
+    
+    /**
+     * Look up tasks by their names for a specific tenant.
+     * 
+     * @param taskNames list of task names to look up
+     * @param tenantId the tenant identifier
+     * @return list of Task objects with metadata
+     */
+    public List<Task> lookupTasksByNames(List<String> taskNames, String tenantId) {
+        logger.info("Looking up {} tasks for tenant {}: {}", taskNames.size(), tenantId, taskNames);
+        
+        try {
+            // TODO: Replace with actual graph/database lookup logic
+            // For now, return mock Task objects with the provided names
+            List<Task> tasks = taskNames.stream()
+                .map(taskName -> {
+                    // Create mock task with default values
+                    Path mockTaskSource = Path.of("/mock/task/source/" + taskName);
+                    String mockUpstreamPlanId = "mock-upstream-plan-" + taskName;
+                    return new Task(taskName, taskName, mockTaskSource, mockUpstreamPlanId);
+                })
+                .collect(Collectors.toList());
+            
+            logger.debug("Successfully looked up {} tasks for tenant {}", tasks.size(), tenantId);
+            return tasks;
+            
+        } catch (Exception e) {
+            logger.error("Failed to lookup tasks for tenant {}: {}", tenantId, e.getMessage(), e);
+            throw new RuntimeException("Task lookup failed for tenant " + tenantId, e);
+        }
+    }
+} 

--- a/services/standalone-py/standalone-py.iml
+++ b/services/standalone-py/standalone-py.iml
@@ -3,7 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.13 (.venv)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/services/task_executor-java/src/main/resources/application.yml
+++ b/services/task_executor-java/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
 
 kafka:
   topic-patterns:
-    controlled-plan-executions: "controlled-plan-executions-.*"
+    task-inputs: "task-inputs-.*"
 
 logging:
   level:


### PR DESCRIPTION
I have created the following plan after thorough exploration and analysis of the codebase. Follow the below plan verbatim. Trust the files and references. Do not re-verify what's written in the plan. Explore only when absolutely necessary. First implement all the proposed file changes and then I'll review all the changes together at the end.

### Observations

I analyzed the scalable-agent-framework codebase and found that the `controlled-plan-executions-{tenantID}` topic is currently used for ControlPlane to publish PlanExecution messages to TaskExecutor. The TaskInput protobuf message already exists in `protos/plan.proto` with the required structure. The change requires updating topic naming, message serialization, control plane routing logic, task executor listeners, and documentation across multiple Java services.

### Approach

The implementation will rename the Kafka topic from `controlled-plan-executions-{tenantID}` to `task-inputs-{tenantID}` and change the message format from PlanExecution to TaskInput protobuf. The ControlPlane will examine incoming PlanExecutions, look up Tasks using `result.next_task_names` (with a stub implementation), create TaskInput messages containing the original PlanExecution, and publish them. TaskExecutors will be updated to consume TaskInput messages instead of PlanExecution messages. All changes maintain protobuf serialization and update documentation accordingly.

### Reasoning

I explored the codebase structure and identified all services involved in the current flow. I examined the protobuf definitions to understand TaskInput structure, found the current topic usage patterns in ControlPlane's ExecutorProducer and TaskExecutor's PlanResultListener, checked serialization utilities in ProtobufUtils, analyzed the routing logic in ExecutionRouter, and reviewed documentation files that reference the old topic name. I also found configuration files that need updates.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant CP as ControlPlane
    participant TLS as TaskLookupService
    participant K as Kafka
    participant TE as TaskExecutor

    Note over CP,TE: New TaskInput Flow

    CP->>CP: Receive PlanExecution
    CP->>CP: Extract result.next_task_names
    CP->>TLS: lookupTasksByNames(next_task_names)
    TLS-->>CP: Return Task metadata (stub)

    loop For each task_name
        CP->>CP: Create TaskInput with:<br/>- input_id<br/>- task_name<br/>- plan_execution (original)
        CP->>K: Publish TaskInput → task-inputs-{tenantId}
    end

    K->>TE: Consume TaskInput (protobuf)
    TE->>TE: Extract PlanExecution from TaskInput
    TE->>TE: Execute task using PlanExecution data
    TE->>K: Publish TaskExecution → task-executions-{tenantId}
```
## Proposed File Changes

### services/common-java/src/main/java/com/pcallahan/agentic/common/TopicNames.java(MODIFY)

Add a new method `taskInputs(String tenantId)` that returns `"task-inputs-" + tenantId`. Update the class-level documentation comment on line 13 to include `task-inputs` in the list of topic prefixes. Update the `isValidTopicName()` method around line 206 to include `task-inputs` as a valid prefix pattern alongside the existing patterns.

### services/common-java/src/main/java/com/pcallahan/agentic/common/KafkaTopicPatterns.java(MODIFY)

Add a new private field `taskInputs` with default value `"task-inputs-.*"` around line 30. Add corresponding getter method `getTaskInputsPattern()` and setter method `setTaskInputs(String taskInputs)` following the same pattern as other topic patterns. Update the `getAllPatterns()` method around line 92 to include the new `taskInputs` pattern in the returned map. Update the `validatePatterns()` method around line 107 to validate the new `taskInputs` pattern.

### services/common-java/src/main/java/com/pcallahan/agentic/common/ProtobufUtils.java(MODIFY)

Add import statement for `io.arl.proto.model.Plan.TaskInput` at the top of the file. Add two new methods: `serializeTaskInput(TaskInput taskInput)` and `deserializeTaskInput(byte[] data)` following the same pattern as the existing PlanExecution serialization methods around lines 106-136. The serialize method should handle null checks, call `taskInput.toByteArray()`, and return null on exceptions with appropriate logging. The deserialize method should handle null/empty data checks, call `TaskInput.parseFrom(data)`, and handle `InvalidProtocolBufferException` with appropriate logging.

### services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/service/TaskLookupService.java(NEW)

Create a new service class with `@Service` annotation. Add a method `lookupTasksByNames(List<String> taskNames, String tenantId)` that returns a `List<Task>` where Task is a simple data class or record containing basic task metadata like name, description, and configuration. For now, implement this as a stub that logs the lookup request and returns mock Task objects with the provided names. Add appropriate logging and error handling. Include TODO comments indicating this should be replaced with actual graph/database lookup logic.

### services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/kafka/ExecutorProducer.java(MODIFY)

Add import for `io.arl.proto.model.Plan.TaskInput`. Add a new method `publishTaskInput(String tenantId, TaskInput taskInput)` following the same pattern as `publishPlanExecution()` around lines 76-101. The method should use `TopicNames.taskInputs(tenantId)` for the topic name, `ProtobufUtils.serializeTaskInput(taskInput)` for serialization, and `taskInput.getTaskName()` as the message key. Include similar error handling, logging, and return a `CompletableFuture<SendResult<String, byte[]>>`. Update the class-level documentation comment around lines 21-24 to mention TaskInput messages being published to task-inputs topics.

### services/control_plane-java/src/main/java/com/pcallahan/agentic/controlplane/service/ExecutionRouter.java(MODIFY)

Add imports for `io.arl.proto.model.Plan.TaskInput` and the new `TaskLookupService`. Add `TaskLookupService` as an autowired dependency. Completely rewrite the `routePlanExecution()` method around lines 98-121. Instead of calling `executorProducer.publishPlanExecution()`, extract the `next_task_names` from `planExecution.getResult().getNextTaskNamesList()`. For each task name, call `taskLookupService.lookupTasksByNames()` to get task metadata, then create a `TaskInput` message with a unique `input_id`, the `task_name`, and the original `planExecution` in the `plan_execution` field. Publish each TaskInput using `executorProducer.publishTaskInput()`. Update logging to reflect the new flow of creating and publishing TaskInputs instead of PlanExecutions.

### services/task_executor-java/src/main/java/com/pcallahan/agentic/taskexecutor/kafka/PlanResultListener.java → services/task_executor-java/src/main/java/com/pcallahan/agentic/taskexecutor/kafka/TaskInputListener.java

Rename this file to TaskInputListener.java to better reflect its new purpose of listening to TaskInput messages instead of PlanExecution messages.

### services/task_executor-java/src/main/java/com/pcallahan/agentic/taskexecutor/kafka/TaskInputListener.java(NEW)

Rename the class from `PlanResultListener` to `TaskInputListener`. Add import for `io.arl.proto.model.Plan.TaskInput`. Update the `@KafkaListener` annotation around line 44 to use `topics = "#{@kafkaTopicPatterns.taskInputsPattern}"` and change the `groupId` to `"task-executor-task-inputs"`. Rename the method from `handlePlanExecution` to `handleTaskInput` and change the parameter type from `PlanExecution` to `TaskInput`. Update the method to use `ProtobufUtils.deserializeTaskInput(record.value())` for deserialization. Extract the `PlanExecution` from `taskInput.getPlanExecution()` and pass it to the existing `taskExecutorService.executeTasksFromPlanExecution()` method, or create a new method that accepts TaskInput directly. Update all logging messages and comments to reference TaskInput instead of PlanExecution.

### services/task_executor-java/src/main/resources/application.yml(MODIFY)

Update the `kafka.topic-patterns` section around line 27. Replace `controlled-plan-executions: "controlled-plan-executions-.*"` with `task-inputs: "task-inputs-.*"`. This ensures the TaskInputListener can properly subscribe to the new topic pattern.

### docs/DEPLOYMENT.md(MODIFY)

Update line 67 in the Kafka section. Replace `controlled-plan-executions` with `task-inputs` in the list of topics: `**Topics**: task-executions, plan-executions, plan-inputs, task-inputs`.

### docs/DataFlow.md(MODIFY)

Update multiple references to the old topic and flow:

1. Line 49: Change `ControlPlane -- "topic controlled-plan-executions-{}" --> Kafka` to `ControlPlane -- "topic task-inputs-{}" --> Kafka`

2. Line 54: Change `Kafka -- "topic controlled-plan-executions-{}" --> TaskExecutor` to `Kafka -- "topic task-inputs-{}" --> TaskExecutor`

3. Line 80: Update the sequence diagram to show `CP->>K: TaskInput (with task metadata + original PlanExecution) → task-inputs-{tenantId}`

4. Line 81: Change `TE->>K: Consume PlanExecution (protobuf)` to `TE->>K: Consume TaskInput (protobuf)`

5. Line 115: Change `CP->>K: Publish PlanExecution (protobuf) → controlled-plan-executions-{tenantId}` to `CP->>K: Publish TaskInput (protobuf) → task-inputs-{tenantId}`

6. Line 121: Update the control topics section to mention TaskInput instead of PlanExecution

7. Line 191: Change `controlled-plan-executions-{tenantId} - ControlPlane publishes PlanExecution protobuf messages for TaskExecutor` to `task-inputs-{tenantId} - ControlPlane publishes TaskInput protobuf messages for TaskExecutor`

8. Line 265: Update the message structure description to reflect TaskInput messages

9. Add a note explaining that ControlPlane now examines PlanExecution.result.next_task_names, looks up Tasks, and creates TaskInput messages containing the original PlanExecution.

### docs/TENANT_AWARE_KAFKA.md(MODIFY)

Update the topic list and patterns:

1. Line 26: Change `controlled-plan-executions-{tenantId} - Controlled plan execution messages` to `task-inputs-{tenantId} - Task input messages`

2. Line 42: Change `controlled-plan-executions: "controlled-plan-executions-.*"` to `task-inputs: "task-inputs-.*"`

Add a note explaining that TaskExecutors now receive TaskInput messages (which contain the original PlanExecution) instead of directly receiving PlanExecution messages.